### PR TITLE
Added a tool to create posts and setting up everything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/tools/config.json

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "dependencies": {
     "dev-to-git": "1.1.0",
     "embedme": "1.11.0",
+    "fs-extra": "^9.0.1",
+    "got": "^11.5.2",
     "prettier": "1.18.2"
   }
 }

--- a/tools/config.json.dist
+++ b/tools/config.json.dist
@@ -1,0 +1,7 @@
+// FILL AND REMOVE .dist EXTENSION FROM FILE NAME
+
+{
+  "apiKey": [YOUR_DEVTO_API_KEY],
+  "templateFolder": "name-of-your-blog-post",
+  "targetFolder": "./blog-posts"
+}

--- a/tools/create-post.js
+++ b/tools/create-post.js
@@ -10,7 +10,7 @@ const devToGit = require('../dev-to-git.json');
 const fsExtra = require('fs-extra');
 const fs = require('fs');
 const join = require('path').join;
-const axios = require('axios');
+const got = require('got');
 
 const postName = process.argv[2];
 const newFilesName = postName.trim().replace(/\s/g, '-');
@@ -26,17 +26,16 @@ fsExtra.renameSync(
 );
 
 console.log('- Creating post on dev.to...');
-axios({
+got('https://dev.to/api/articles', {
   method: 'post',
-  data: { article: { title: postName } },
-  url: 'https://dev.to/api/articles',
+  json: { article: { title: postName, body_markdown: '' } },
   responseType: 'json',
   headers: {
     'Content-Type': 'application/json',
     'api-key': config.apiKey,
   },
 })
-  .then(res => res.data.id)
+  .then(({ body }) => body.id)
   .then(id => {
     console.log(`- Post created successfully`);
     console.log(`- The new post id is #${id}`);

--- a/tools/create-post.js
+++ b/tools/create-post.js
@@ -1,0 +1,67 @@
+#! /usr/bin/env node
+
+/**
+ * Tool to create new posts on dev.to and setup everything on your local machine.
+ * example: ./tools/create-post.js "Here my new post title"
+ */
+
+const config = require('./config.json');
+const devToGit = require('../dev-to-git.json');
+const fsExtra = require('fs-extra');
+const fs = require('fs');
+const join = require('path').join;
+const axios = require('axios');
+
+const postName = process.argv[2];
+const newFilesName = postName.trim().replace(/\s/g, '-');
+
+const targetFolder = config.targetFolder;
+const templatePath = join(targetFolder, config.templateFolder);
+
+console.log('- Creating the new post structure');
+fsExtra.copySync(templatePath, join(targetFolder, newFilesName));
+fsExtra.renameSync(
+  join(targetFolder, newFilesName, config.templateFolder + '.md'),
+  join(targetFolder, newFilesName, newFilesName + '.md'),
+);
+
+console.log('- Creating post on dev.to...');
+axios({
+  method: 'post',
+  data: { article: { title: postName } },
+  url: 'https://dev.to/api/articles',
+  responseType: 'json',
+  headers: {
+    'Content-Type': 'application/json',
+    'api-key': config.apiKey,
+  },
+})
+  .then(res => res.data.id)
+  .then(id => {
+    console.log(`- Post created successfully`);
+    console.log(`- The new post id is #${id}`);
+    return id;
+  })
+  .then(id => {
+    newDevToGit = {
+      id: id,
+      relativePathToArticle: `./blog-posts/${newFilesName}/${newFilesName}.md`,
+    };
+    console.log(`- Adding new object relation ${JSON.stringify(newDevToGit)}`);
+    devToGit.push(newDevToGit);
+    console.log('- Saving new dev-to-git.json');
+    return writeFilePromise(join('.', 'dev-to-git.json'), JSON.stringify(devToGit));
+  })
+  .catch(e => {
+    console.error('- Ups something went wrong!');
+    console.error(e.message);
+  });
+
+function writeFilePromise(path, data) {
+  return new Promise((res, rej) =>
+    fs.writeFile(path, data, 'utf8', e => {
+      if (e) rej(e);
+      res();
+    }),
+  );
+}


### PR DESCRIPTION
Hello, I added a new script to the project to automate how we create posts and setting up everything on the project.

To use the tool you need to add your dev.to key on the config.json.dist and remove .dist extension from the file. After that you run the command:
`./tools/create-post.js "My new titlte"`

What the script does:
- Copy your template directory
- Rename the new directory replacing spaces with hyphen
- Call dev.to API rest to create the new post and get the ID
- Add the new directory and ID object on dev-to-git.json