### PR TITLE
Update .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,6 +7,6 @@
   "trailingComma": "all",
   "bracketSpacing": true,
   "arrowParens": "avoid",
-  "proseWrap": "preserve",
+  "proseWrap": "never",
   "htmlWhitespaceSensitivity": "ignore"
 }


### PR DESCRIPTION
As per https://github.com/forem/forem/issues/1492 the dev.to renderer interprets line breaks in markdown as actual linebreaks.

Removing this formatting flag stops articles looking weird because of odd linebreak behaviour.